### PR TITLE
doc: restore broken star history chart

### DIFF
--- a/README.cn.md
+++ b/README.cn.md
@@ -25,6 +25,8 @@
 
 ![Palworld Pal Editor](.github/assets/readme-pal-editor-zh.webp)
 
+<a href="https://star-history.dera.page/#KrisCris/Palworld-Pal-Editor&type=Date"><img width="720" alt="Star History Chart" src="https://star-history.dera.page/svg?repos=KrisCris/Palworld-Pal-Editor&type=Date"></a>&nbsp;
+
 > [!CAUTION]
 > 修改前请备份存档。修改器会自动创建备份，但仍建议你另外保留一份副本。
 

--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@
 
 ![Palworld Pal Editor](.github/assets/readme-pal-editor-en.webp)
 
+<a href="https://star-history.dera.page/#KrisCris/Palworld-Pal-Editor&type=Date"><img width="720" alt="Star History Chart" src="https://star-history.dera.page/svg?repos=KrisCris/Palworld-Pal-Editor&type=Date"></a>&nbsp;
+
 > [!CAUTION]
 > Back up your save before editing it. The editor creates backups, but you should keep your own copy as well.
 


### PR DESCRIPTION
The star history chart in the READMEs is currently broken because the previous chart service can no longer render under the stargazer API restrictions. This restores the chart in both README.md and README.cn.md at its original location using a working chart service, so contributors and users can see the project's growth again.